### PR TITLE
(feat) Implements transition from ARScan to AddProduct VC

### DIFF
--- a/ScannAR/ScannAR/ARScanner Scene/Controllers/ARScan.swift
+++ b/ScannAR/ScannAR/ARScanner Scene/Controllers/ARScan.swift
@@ -410,6 +410,7 @@ class ARScan {
             validSizeRange.contains(boundingBox.extent.z) {
             // Check that the volume of the bounding box is at least 250 cubic centimeters.
             let volume = boundingBox.extent.x * boundingBox.extent.y * boundingBox.extent.z
+            bestBoxSize = (boundingBox.extent.x, boundingBox.extent.y, boundingBox.extent.z)
             return volume >= 0.00025
         }
         

--- a/ScannAR/ScannAR/ARScanner Scene/ViewControllers/ARScanMenuScreenViewController.swift
+++ b/ScannAR/ScannAR/ARScanner Scene/ViewControllers/ARScanMenuScreenViewController.swift
@@ -80,6 +80,8 @@ class ARScanMenuScreenViewController: UIViewController, UIImagePickerControllerD
         
         self.navigationController?.pushViewController(vc, animated: false)
     }
+    
+    
    
     func createSession() {
         session = AVCaptureSession()

--- a/ScannAR/ScannAR/ViewController/AddProductViewController.swift
+++ b/ScannAR/ScannAR/ViewController/AddProductViewController.swift
@@ -10,11 +10,21 @@ import UIKit
 
 class AddProductViewController: UIViewController {
 
+    
+    var previewImage: UIImage?
+    var bestBoxSize: (length: Float?, width: Float?, height: Float?) = (length: 1, width: 1,height: 1)
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
         setupDelegates()
         updateViews()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super .viewWillAppear(animated)
+        lengthTextField.text = "\(bestBoxSize.length! * 39.3701)"
+        widthTextField.text = "\(bestBoxSize.width! * 39.3701)"
+        heightTextField.text = "\(bestBoxSize.height! * 39.3701)"
     }
     // MARK: - Private Methods
     
@@ -25,7 +35,7 @@ class AddProductViewController: UIViewController {
         heightTextField.keyboardType = UIKeyboardType.decimalPad
         widthTextField.keyboardType = UIKeyboardType.decimalPad
         
-        manualEntryStackView.isHidden = true
+        manualEntryStackView.isHidden = false
     }
     
     private func setupDelegates() {

--- a/ScannAR/ScannAR/ViewController/ScannARMainViewController.swift
+++ b/ScannAR/ScannAR/ViewController/ScannARMainViewController.swift
@@ -14,6 +14,7 @@ class ScannARMainViewController: UIViewController, UICollectionViewDelegate, UIC
     @IBAction func unwindToScannARMainViewController(segue: UIStoryboardSegue) {
         //nothing goes here
     }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         


### PR DESCRIPTION
After successful scan, transitions to AddProduct VC and fills LxWxH text fields + object preview image passed.